### PR TITLE
Add additional manifest.json aliases

### DIFF
--- a/commands/info/manifest.json
+++ b/commands/info/manifest.json
@@ -111,11 +111,19 @@
         "value": "/distros/arch.json"
       },
       {
-        "name": "Arch Variants",
+        "name": "Arch Based",
+        "value": "/distros/arch_variants.json"
+      },
+      {
+        "name": "Archbased",
         "value": "/distros/arch_variants.json"
       },
       {
         "name": "Arch Variant",
+        "value": "/distros/arch_variants.json"
+      },
+      {
+        "name": "Arch Variants",
         "value": "/distros/arch_variants.json"
       },
       {
@@ -124,14 +132,6 @@
       },
       {
         "name": "Archvariants",
-        "value": "/distros/arch_variants.json"
-      },
-      {
-        "name": "Arch Based",
-        "value": "/distros/arch_variants.json"
-      },
-      {
-        "name": "Archbased",
         "value": "/distros/arch_variants.json"
       },
       {
@@ -383,11 +383,11 @@
         "value": "/linux/shell.json"
       },
       {
-        "name": "Snaps",
+        "name": "Snap",
         "value": "/linux/snaps.json"
       },
       {
-        "name": "Snap",
+        "name": "Snaps",
         "value": "/linux/snaps.json"
       },
       {

--- a/commands/info/manifest.json
+++ b/commands/info/manifest.json
@@ -115,6 +115,26 @@
         "value": "/distros/arch_variants.json"
       },
       {
+        "name": "Arch Variant",
+        "value": "/distros/arch_variants.json"
+      },
+      {
+        "name": "Archvariant",
+        "value": "/distros/arch_variants.json"
+      },
+      {
+        "name": "Archvariants",
+        "value": "/distros/arch_variants.json"
+      },
+      {
+        "name": "Arch Based",
+        "value": "/distros/arch_variants.json"
+      },
+      {
+        "name": "Archbased",
+        "value": "/distros/arch_variants.json"
+      },
+      {
         "name": "Artix",
         "value": "/distros/arch_variants.json"
       },
@@ -364,6 +384,10 @@
       },
       {
         "name": "Snaps",
+        "value": "/linux/snaps.json"
+      },
+      {
+        "name": "Snap",
         "value": "/linux/snaps.json"
       },
       {


### PR DESCRIPTION
Some things lack useful aliases, this adds aliases to snap and arch variants that many users may find useful with info