### PR TITLE
Added CachyOS to unsupported distros

### DIFF
--- a/commands/info/supported.json
+++ b/commands/info/supported.json
@@ -84,6 +84,13 @@
     "notes": "BOSS Linux is a Linux distro created by CDAC, part of the Indian Government"
   },
   {
+    "name": "CachyOS",
+    "supported": "No",
+    "experience_level": "Advanced",
+    "recommended": "No",
+    "notes": null
+  },
+  {
     "name": "CentOS Stream",
     "supported": "No",
     "experience_level": "Advanced",

--- a/commands/info/supported.md
+++ b/commands/info/supported.md
@@ -12,6 +12,7 @@
 |BlackArch Linux|No|Advanced|No||
 |Bodhi Linux|No|N/A|No||
 |BOSS Linux|No|N/A|No|BOSS Linux is a Linux distro created by CDAC, part of the Indian Government|
+|CachyOS|No|Advanced|No||
 |CentOS Stream|No|Advanced|No||
 |Chrome OS|Yes|Beginner|No||
 |Clear Linux|No|Advanced|No||


### PR DESCRIPTION
Given that Arch derivatives are unsupported in Discord Linux, I added CachyOS to the list as it did not look like it was in the list of distros mentioned.
